### PR TITLE
row 'exon_changes' had wrong exon count caused by rounding

### DIFF
--- a/R/htmlReports.R
+++ b/R/htmlReports.R
@@ -36,8 +36,6 @@ DEXSeqHTML <- function(object, genes=NULL, path="DEXSeqReport", file="testForDEU
    }else{
       gns <- genes
    }
-      
-   results[,c("dispersion", "pvalue", "padj")] <- round(results[,c("dispersion", "pvalue", "padj")], 3)
    
    if(!all(gns %in% object$groupID)){
       stop("The geneIDs provided are not in the ecs object")}
@@ -84,6 +82,7 @@ DEXSeqHTML <- function(object, genes=NULL, path="DEXSeqReport", file="testForDEU
       loc <- as.character(results$groupID) %in% as.character(gene)
       ### this makes the page where to explore the pvalues ###
       subres <- results[loc,]
+      subres[c("dispersion", "pvalue", "padj")] <- round(subres[c("dispersion", "pvalue", "padj")], 3)
       submatcol <- matcol[loc,]
       rownames(subres) <- NULL
       genpage <- openPage(paste(ptowrite, nameforlinks, "results.html", sep=""))


### PR DESCRIPTION
Due to rounding of  'padj' the row 'exon_changes' could be wrong.

Example: Table shows zero exon changes for a gene --> row should not be in result table...
![zero](https://user-images.githubusercontent.com/4368200/98822245-e2fa0b80-2430-11eb-806d-cae225525dc8.png)

...but one exon is significant. 
![zero2](https://user-images.githubusercontent.com/4368200/98822616-57cd4580-2431-11eb-9486-da944d7be49c.png)
